### PR TITLE
Improve the output of `torba verify` and `require 'torba/verify'`.

### DIFF
--- a/lib/torba.rb
+++ b/lib/torba.rb
@@ -73,8 +73,12 @@ module Torba
   # @yield a block, converts common exceptions into useful messages
   def self.pretty_errors
     yield
-  rescue Errors::UnbuiltPackage
+  rescue Errors::MissingPackages => e
     ui.error "Your Torba is not packed yet."
+    ui.error "Missing packages:"
+    e.packages.each do |package|
+      ui.error "  * #{package.name}"
+    end
     ui.suggest "Run `bundle exec torba pack` to install missing packages."
     exit(false)
   rescue Errors::ShellCommandFailed => e

--- a/lib/torba/manifest.rb
+++ b/lib/torba/manifest.rb
@@ -5,6 +5,16 @@ require "torba/remote_sources/targz"
 require "torba/remote_sources/npm"
 
 module Torba
+  module Errors
+    class MissingPackages < StandardError
+      attr_reader :packages
+
+      def initialize(packages)
+        @packages = packages
+        super
+      end
+    end
+  end
   # Represents Torbafile.
   class Manifest
     # all packages defined in Torbafile
@@ -103,7 +113,11 @@ module Torba
     # Verifies all {#packages}
     # @return [void]
     def verify
-      packages.each(&:verify)
+      missing = packages.reject(&:verify)
+
+      if missing.any?
+        raise Errors::MissingPackages.new(missing)
+      end
     end
   end
 end

--- a/lib/torba/package.rb
+++ b/lib/torba/package.rb
@@ -5,8 +5,6 @@ require "torba/import_list"
 
 module Torba
   module Errors
-    UnbuiltPackage = Class.new(StandardError)
-
     class NothingToImport < StandardError
       attr_reader :package, :path
 
@@ -58,9 +56,9 @@ module Torba
       end
     end
 
-    # @raise [Errors::UnbuiltPackage] if package is not build.
+    # @return [false] if package is not build.
     def verify
-      raise Errors::UnbuiltPackage.new(name) unless built?
+      built?
     end
 
     # Cache remote source and import specified assets to {#load_path}.

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -102,5 +102,14 @@ module Torba
         end
       end
     end
+
+    def test_verify
+      manifest.zip "angular", url: "http://angularjs.com/angularjs.zip"
+      manifest.npm package: "coffee-script", version: "1.8.3"
+
+      error = assert_raises(Torba::Errors::MissingPackages) { manifest.verify }
+
+      assert_equal error.packages.map(&:name), %w(angular coffee-script)
+    end
   end
 end


### PR DESCRIPTION
The exception that gets raised now list the missing packages, as the following:

```sh
$ bin/torba verify
Your Torba is not packed yet.
Missing packages:
  * jquery
  * jquery-ujs
Run `bundle exec torba pack` to install missing packages.
```