### PR TITLE
Do not add the `.erb` extension for stylesheets that don't need it.

### DIFF
--- a/lib/torba/package.rb
+++ b/lib/torba/package.rb
@@ -163,7 +163,12 @@ module Torba
           image_asset.logical_path
         end
 
-        new_absolute_path = File.join(load_path, asset.logical_path + ".erb")
+        if content == new_content
+          new_absolute_path = File.join(load_path, asset.logical_path)
+        else
+          new_absolute_path = File.join(load_path, asset.logical_path + ".erb")
+        end
+
         ensure_directory(new_absolute_path)
         File.write(new_absolute_path, new_content)
       end

--- a/test/package_test.rb
+++ b/test/package_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+module Torba
+  class PackageTest < Minitest::Test
+    def source_dir
+      @source_dir ||= File.join(Torba.home_path, "source")
+    end
+
+    def touch(path)
+      super File.join(source_dir, path)
+    end
+
+    def fixture(path, content = nil)
+      touch(path)
+      if content
+        File.write(File.join(source_dir, path), content)
+      end
+    end
+
+    def test_package_css_with_urls
+      touch "image.png"
+      fixture "hello.css" , "body {\nbackground-image: url(image.png)\n}"
+      source = Torba::Test::RemoteSource.new(source_dir)
+      package = Package.new("package", source, import: ["hello.css", "image.png"])
+
+      package.build
+
+      assert_exists File.join(package.load_path, "package", "hello.css.erb")
+      assert_exists File.join(package.load_path, "package", "image.png")
+    end
+
+    def test_package_css_without_urls
+      fixture "hello.css"
+      source = Torba::Test::RemoteSource.new(source_dir)
+      package = Package.new("package", source, import: ["hello.css"])
+
+      package.build
+
+      assert_exists File.join(package.load_path, "package", "hello.css")
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,6 +48,8 @@ module Torba
       end
 
       def ensure_cached; end
+
+      def digest; '' end
     end
   end
 end


### PR DESCRIPTION
Some stylesheets, like `normalize` or sprockets-ready scss files don't need to include the `.erb` extension for dealing with asset paths. We can skip the extension on those cases and avoid an extra processing layer on the compilation steps.

The only tests I've found that deal with the `.erb` check are the acceptance ones, and the test package does not include an stylesheet that can be used for testing this - should I add new `test_zip/npm/etc_with_plain_stylesheet` tests that use a different package or there is other angle we can take to test this?