### PR TITLE
add alias_method install for Torba.pack

### DIFF
--- a/lib/torba/cli.rb
+++ b/lib/torba/cli.rb
@@ -8,6 +8,7 @@ module Torba
       Torba.pretty_errors { Torba.pack }
       Torba.ui.confirm "Torba has been packed!"
     end
+    map install: :pack
 
     desc "verify", "check if all packages are prepared"
     def verify


### PR DESCRIPTION
This PR adds an alias method for `#install` for `#pack`. This makes the CLI similar to bundler with deployment going something like `bundle install && torba install`. 