### PR TITLE
Add Heroku support with `rake assets:precompile` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,16 @@ export TORBA_HOME_PATH=/var/www/my_app/shared/torba
 
 There is no need to add a symlink.
 
+### Troubleshooting
+
+If you are getting an error like `Your Torba is not packed yet` when trying to
+run `rake assets:precompile` (or `bin/rails assets:precompile` in Rails 5),
+set the `TORBA_DONT_VERIFY` environment variable, like this:
+
+```bash
+TORBA_DONT_VERIFY=1 bin/rake assets:precompile
+```
+
 [bower]: http://bower.io/
 [sprockets]: https://github.com/rails/sprockets/
 [sprockets-load-path]: https://github.com/rails/sprockets#the-load-path

--- a/README.md
+++ b/README.md
@@ -251,10 +251,43 @@ default), except that Torba does have a way to specify exact list of files to im
 
 ## Deployment
 
-1. Specify `TORBA_HOME_PATH` env variable pointing to a persistent directory writable by your
-   deploy user. For Capistrano it should be `shared/`.
-2. Add `bundle exec torba pack` to your deployment script right after `bundle install`. It's safe
-   and fairly cheap to run it unconditionally on each deployment.
+In Rails apps, Torba automatically hooks into the existing `assets:precompile`
+Rake task to ensure that `torba pack` is executed. This means that Rails
+deployments will "just work", although there are some optimizations you can make
+as explained below.
+
+### Heroku
+
+You will need to specify some config vars to ensure Torba's files are placed in
+locations suitable for the Heroku platform.
+
+`TORBA_HOME_PATH` should be within your app so that Torba's assets are included
+in the slug.
+
+`TORBA_CACHE_PATH` should make use of the `tmp/cache/assets` directory. This is
+where the Ruby buildpack expects cached files to be stored related to the
+`assets:precompile` step. This way Torba doesn't have to download packages fresh
+every time.
+
+```bash
+heroku config:set TORBA_HOME_PATH=vendor/torba TORBA_CACHE_PATH=tmp/cache/assets/torba
+```
+
+Now your Heroku app is good to go.
+
+### Capistrano
+
+Specify the `TORBA_HOME_PATH` env variable pointing to a persistent directory
+writable by your deploy user and shared across releases. Capistrano's `shared`
+directory is good for this.
+
+For example:
+
+```bash
+export TORBA_HOME_PATH=/var/www/my_app/shared/torba
+```
+
+There is no need to add a symlink.
 
 [bower]: http://bower.io/
 [sprockets]: https://github.com/rails/sprockets/

--- a/lib/torba/rails.rb
+++ b/lib/torba/rails.rb
@@ -4,5 +4,10 @@ module Torba
       Rails.application.config.assets.paths.concat(Torba.load_path)
       Rails.application.config.assets.precompile.concat(Torba.non_js_css_logical_paths)
     end
+
+    rake_tasks do
+      require "torba/rake_task"
+      Torba::RakeTask.new("torba:pack", :before => "assets:precompile")
+    end
   end
 end

--- a/lib/torba/rake_task.rb
+++ b/lib/torba/rake_task.rb
@@ -1,0 +1,53 @@
+require "torba"
+require "rake/tasklib"
+
+module Torba
+  # Calling Torba::RakeTask.new defines a "torba:pack" Rake task that does the
+  # same thing as `bundle exec torba pack`. Furthermore, if the :before option
+  # is specified, the "torba:pack" task will be installed as a prerequisite to
+  # the specified task.
+  #
+  # This is useful for deployment because it allows for packing as part of the
+  # "assets:precompile" flow, which platforms like Heroku already know to
+  # invoke. By hooking into "assets:precompile" as a prerequisite, Torba can
+  # participate automatically, with no change to the deployment process.
+  #
+  # Typical use is as follows:
+  #
+  #   # In Rakefile
+  #   require "torba/rake_task"
+  #   Torba::RakeTask.new("torba:pack", :before => "assets:precompile")
+  #
+  # Note that when you require "torba/rails" in a Rails app, this Rake task is
+  # installed for you automatically. You only need to install the task yourself
+  # if you are using something different, like Sinatra.
+  #
+  class RakeTask < Rake::TaskLib
+    attr_reader :torba_pack_task_name
+
+    def initialize(name="torba:pack", options={})
+      @torba_pack_task_name = name
+      define_task
+      install_as_prerequisite(options[:before]) if options[:before]
+    end
+
+    private
+
+    def define_task
+      desc "Download and prepare all packages defined in Torbafile"
+      task torba_pack_task_name do
+        Torba.pretty_errors { Torba.pack }
+      end
+    end
+
+    def install_as_prerequisite(other_task)
+      ensure_task_defined(other_task)
+      Rake::Task[other_task].enhance([torba_pack_task_name])
+    end
+
+    def ensure_task_defined(other_task)
+      return if Rake::Task.task_defined?(other_task)
+      Rake::Task.define_task(other_task)
+    end
+  end
+end

--- a/lib/torba/verify.rb
+++ b/lib/torba/verify.rb
@@ -1,7 +1,14 @@
 require "torba"
 
-if STDOUT.tty?
-  Torba.pretty_errors { Torba.verify }
-else
-  Torba.verify
+# We purposely skip verification during Rake execution, because Rake is used to
+# run the Torba:RakeTask during the "assets:precompile" stage of deployment. In
+# this case it is OK that the Torbafile hasn't been packed yet, because we are
+# about to do so.
+#
+unless defined?(Rake::Task)
+  if STDOUT.tty?
+    Torba.pretty_errors { Torba.verify }
+  else
+    Torba.verify
+  end
 end

--- a/lib/torba/verify.rb
+++ b/lib/torba/verify.rb
@@ -5,7 +5,7 @@ require "torba"
 # this case it is OK that the Torbafile hasn't been packed yet, because we are
 # about to do so.
 #
-unless defined?(Rake::Task)
+unless ENV["TORBA_DONT_VERIFY"] || defined?(Rake::Task)
   if STDOUT.tty?
     Torba.pretty_errors { Torba.verify }
   else

--- a/test/rake_task_test.rb
+++ b/test/rake_task_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+require "torba/rake_task"
+
+module Torba
+  class RakeTaskTest < Minitest::Test
+    include Rake::DSL
+
+    def setup
+      task "environment"
+      task "assets:precompile" => "environment"
+      Torba::RakeTask.new("torba:pack", :before => "assets:precompile")
+    end
+
+    def teardown
+      Rake::Task.clear
+    end
+
+    def test_torba_pack_task_is_defined
+      assert(Rake::Task.task_defined?("torba:pack"))
+    end
+
+    def test_torba_pack_task_has_description
+      torba_task = Rake::Task["torba:pack"]
+      torba_task.comment =~ /Torbafile/
+    end
+
+    def test_torba_pack_is_installed_as_prerequisite
+      precompile_task = Rake::Task["assets:precompile"]
+      assert_equal(%w(environment torba:pack), precompile_task.prerequisites)
+    end
+
+    def test_invoking_torba_pack
+      Torba.expects(:pack).once
+      Rake::Task["torba:pack"].invoke
+    end
+
+    def test_defines_task_if_doesnt_exist
+      Rake::Task.clear
+      Torba::RakeTask.new("torba:pack", :before => "something:else")
+
+      assert(Rake::Task.task_defined?("something:else"))
+      other_task = Rake::Task["something:else"]
+      assert_equal(%w(torba:pack), other_task.prerequisites)
+    end
+
+    def test_alternative_task_name_can_be_specified
+      Rake::Task.clear
+      Torba::RakeTask.new("package")
+
+      assert(Rake::Task.task_defined?("package"))
+
+      Torba.expects(:pack).once
+      Rake::Task["package"].invoke
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require "torba"
 require "torba/remote_sources/common"
 
 require "minitest/autorun"
+require "mocha/mini_test"
 require "tmpdir"
 require "fileutils"
 

--- a/torba.gemspec
+++ b/torba.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.4"
+  spec.add_development_dependency "mocha"
 end


### PR DESCRIPTION
This PR adds automatic (almost) Heroku support to Torba.

It works by adding a Rake task to Rails apps called `torba:pack`. This task is installed as a *prerequisite* for `assets:precompile`, ensuring that it is automatically run by the standard Heroku Ruby buildpack, as [discussed here](https://github.com/heroku/heroku-buildpack-ruby/issues/442#issuecomment-164174721).

The only manual step is setting Heroku-friendly `TORBA_HOME_PATH` and `TORBA_CACHE_PATH` config vars. This ensures that Torba's cache is shared across deploys. I documented this in the README.

I tested this with a brand new Rails 4.2.5 app deployed to Heroku, and it works great.

**Caveat:** I had to change the behavior of Torba's verification. For Rails specifically, I added a `torba/rails/verify.rb` that differs from the standard `torba/verify.rb` in that it disables verification when Rake is loaded. I had to do this because it was impossible to run `rake assets:precompile` otherwise.

@nashbridges Does this look good to you? If so I will clean up the commits and work on adding tests.

Fixes #4.