### PR TITLE
add Torba.clean to remove Torba.home_path from cli

### DIFF
--- a/lib/torba.rb
+++ b/lib/torba.rb
@@ -61,6 +61,11 @@ module Torba
     manifest.verify
   end
 
+  # removes @home_path
+  def self.clean
+    FileUtils.rm_rf self.home_path
+  end
+
   # @return [String] unique short fingerprint/hash for given string
   # @param [String] string to be hashed
   #

--- a/lib/torba/cli.rb
+++ b/lib/torba/cli.rb
@@ -14,5 +14,11 @@ module Torba
       Torba.pretty_errors { Torba.verify }
       Torba.ui.confirm "Torba is prepared!"
     end
+
+    desc "clean", "delete all contents of Torba.home_path"
+    def clean
+      Torba.pretty_errors { Torba.clean }
+      Torba.ui.confirm "Torba has been cleaned!"
+    end
   end
 end

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -111,5 +111,12 @@ module Torba
 
       assert_equal error.packages.map(&:name), %w(angular coffee-script)
     end
+
+    def test_clean
+      torba_home_path = '/tmp/torba_home_path'
+      FileUtils.mkdir_p torba_home_path
+      FileUtils.rm_rf torba_home_path
+      refute_exists torba_home_path
+    end
   end
 end


### PR DESCRIPTION
This PR adds a `clean` method to the CLI to remove the home_path.