### PR TITLE
add -s to curl to silence download progress

### DIFF
--- a/lib/torba/remote_sources/get_file.rb
+++ b/lib/torba/remote_sources/get_file.rb
@@ -14,7 +14,7 @@ module Torba
 
         Torba.ui.info "downloading '#{url}'"
 
-        command = "curl -Lf -o #{tempfile.path} #{url}"
+        command = "curl -s -Lf -o #{tempfile.path} #{url}"
         system(command) || raise(Errors::ShellCommandFailed.new(command))
 
         tempfile


### PR DESCRIPTION
This PR adds `-s` to the curl command. Doing keeps the output much prettier and easier to read.