### PR TITLE
hotfix: Let curl retry 10 times if it fails

### DIFF
--- a/lib/torba/remote_sources/get_file.rb
+++ b/lib/torba/remote_sources/get_file.rb
@@ -14,7 +14,7 @@ module Torba
 
         Torba.ui.info "downloading '#{url}'"
 
-        command = "curl -Lf -o #{tempfile.path} #{url}"
+        command = "curl --retry 5 --retry-max-time 60 -Lf -o #{tempfile.path} #{url}"
         system(command) || raise(Errors::ShellCommandFailed.new(command))
 
         tempfile


### PR DESCRIPTION
When using gh_release I found that github often gives me 502 bad gateway.
That makes torba fail. It would be great to retry so I suggest to add a --retry 10 to curl.