### PR TITLE
Dot not pollute `precompile` config with all assets on Sprockets 4.

### DIFF
--- a/lib/torba/rails.rb
+++ b/lib/torba/rails.rb
@@ -2,7 +2,13 @@ module Torba
   class Engine < Rails::Engine
     initializer "torba.assets" do |app|
       Rails.application.config.assets.paths.concat(Torba.load_path)
-      Rails.application.config.assets.precompile.concat(Torba.non_js_css_logical_paths)
+      unless using_sprockets4?
+        Rails.application.config.assets.precompile.concat(Torba.non_js_css_logical_paths)
+      end
+    end
+
+    def using_sprockets4?
+      Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('4.x')
     end
 
     rake_tasks do


### PR DESCRIPTION
Precompiled assets should be linked through the `app/assets/config/manifest.js` instead. Details on the manifest syntax are explained on Sprockets upgrade guide under *Preference for asset manifest and links* https://github.com/rails/sprockets/blob/master/UPGRADING.md.

This can be quite a breaking change for existing apps and sprockets 4 isn't out yet, so its OK to hold on a little before merging and releasing this, but I wanted to get it out of my app and start a conversation.