### PR TITLE
targz: added --no-same-owner

### DIFF
--- a/lib/torba/remote_sources/targz.rb
+++ b/lib/torba/remote_sources/targz.rb
@@ -25,7 +25,7 @@ module Torba
 
           tempfile = GetFile.process(url)
 
-          command = "gzip -qcd #{tempfile.path} | tar -mxpf - --strip-components=1 -C #{cache_path}"
+          command = "gzip -qcd #{tempfile.path} | tar --no-same-owner -mxpf - --strip-components=1 -C #{cache_path}"
           system(command) || raise(Errors::ShellCommandFailed.new(command))
         end
       rescue


### PR DESCRIPTION
It fixes issue when running on unpriveleged containers.

Usually it generates following error:

```
...
tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
tar: Ignoring unknown extended header keyword 'NODETAR.blksize'
tar: Ignoring unknown extended header keyword 'FILENAME1.txt'
tar: Ignoring unknown extended header keyword 'FILENAME2.txt'
tar: file-name.txt: Cannot change ownership to uid 1119519827, gid 1490099278: Invalid argument
tar: Exiting with failure status due to previous errors
```