### PR TITLE
Torbafile nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ duplication:
 4.  Stylesheets (if any) are converted to ".css.erb" with "asset_path" helpers used in "url(...)"
 statements.
 
+#### Nesting
+
+You can create separated _Torbafile_, for example, `<project>/shared/Torbafile` and include it via `require` directive using relative path.
+
+In `<project>/Torbafile`:
+
+```ruby
+#= require shared/Torbafile
+```
+
 ### :import option
 
 Copying whole remote source's content has the disadvantage of using remote source specific paths in your

--- a/test/acceptance-cli/pack_test.rb
+++ b/test/acceptance-cli/pack_test.rb
@@ -2,6 +2,14 @@ require "test_helper"
 
 module Torba
   class PackTest < Minitest::Test
+    def test_nested
+      out, err, status = torba("pack", torbafile: "05_nested.rb")
+      assert status.success?, err
+      assert_includes out, "Torba has been packed!"
+      assert_dirs_equal "test/fixtures/home_path/01", path_to_packaged("trumbowyg")
+      assert_dirs_equal "test/fixtures/home_path/02", path_to_packaged("lo_dash")
+    end
+
     def test_zip
       out, err, status = torba("pack", torbafile: "01_zip.rb")
       assert status.success?, err

--- a/test/fixtures/torbafiles/05_nested.rb
+++ b/test/fixtures/torbafiles/05_nested.rb
@@ -1,0 +1,10 @@
+#= require additionally/child
+
+gh_release "trumbowyg",
+  source: "torba-rb/Trumbowyg",
+  tag: "1.1.6",
+  import: %w[
+    dist/trumbowyg.js
+    dist/ui/trumbowyg.css
+    dist/ui/images/
+  ]

--- a/test/fixtures/torbafiles/additionally/child
+++ b/test/fixtures/torbafiles/additionally/child
@@ -1,0 +1,1 @@
+npm "lo_dash", package: "lodash", version: "0.1.0", import: ["lodash.js"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require "torba/remote_sources/common"
 
 require "minitest/autorun"
 require "minitest/assert_dirs_equal"
-require "mocha/mini_test"
+require "mocha/minitest"
 require "tmpdir"
 require "fileutils"
 require "open3"


### PR DESCRIPTION
Now we can create separated _Torbafile_, for example, `<project>/shared/Torbafile` and include it via `require` directive using relative path.

 In `<project>/Torbafile`:
 ```ruby
#= require shared/Torbafile
```