### PR TITLE
Refresh test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - jruby-19mode
+  - jruby
 bundler_args: --without doc debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,10 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - jruby
 bundler_args: --without doc debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ rvm:
   - 2.1
   - 2.2
   - jruby-19mode
-  - rbx-2
 bundler_args: --without doc debug

--- a/lib/torba/remote_sources/common.rb
+++ b/lib/torba/remote_sources/common.rb
@@ -10,7 +10,7 @@ module Torba
       def [](pattern)
         ensure_cached
 
-        Dir.glob(File.join(cache_path, pattern)).reject{ |path| File.directory?(path) }.map do |path|
+        Dir.glob(File.join(cache_path, pattern)).sort.reject{ |path| File.directory?(path) }.map do |path|
           [File.absolute_path(path), path.sub(/#{cache_path}\/?/, "")]
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require "torba/remote_sources/common"
 
 require "minitest/autorun"
 require "minitest/assert_dirs_equal"
-require "mocha/mini_test"
+require "mocha/minitest"
 require "tmpdir"
 require "fileutils"
 require "open3"
@@ -49,7 +49,7 @@ module Torba
       end
 
       def path_to_packaged(name, home = torba_tmp_dir)
-        path = Dir.glob("#{home}/*").grep(Regexp.new(name)).first
+        path = Dir.glob("#{home}/*").sort.grep(Regexp.new(name)).first
         assert path, "Couldn't find packaged #{name.inspect} in #{home.inspect}"
         path
       end

--- a/torba.gemspec
+++ b/torba.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor", "~> 0.19.1"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.4"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "assert_dirs_equal", "~> 0.1"


### PR DESCRIPTION
1. Make tests green again by ensuring results from `Dir.glob` are sorted. The sorting was not needed on Ubuntu 12 (precise), but on Ubuntu 16 (xenial) results are flaky.
2. Updated legacy `require "mocha/mini_test"` call.
3. Tested against MRI 2.3..2.7 versions. EOL versions are still supported due to specificity of the gem (Torba might be useful even for legacy Rails 3.2 projects). 
4. In order to support Ruby 2.7, "bundler" version had to be relaxed to support Bundler v2. Rake has been relaxed for consistency.
5. Rubinius support has been dropped, since it is [not available on xenial](https://docs.travis-ci.com/user/languages/ruby/#rubinius).