### PR TITLE
Relax "thor" dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Enhancements
+
+* Thor dependency has been relaxed to support Rails 6.x.
+
 ## Version 1.0.1
 
 ### Bug fixes

--- a/torba.gemspec
+++ b/torba.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "thor", "~> 0.19.1"
+  spec.add_dependency "thor", ">= 0.19.1", "< 2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Any version up until 2 is now allowed, otherwise one can not install Rails 6.1:

```
Resolving dependencies...
Bundler could not find compatible versions for gem "thor":
  In Gemfile:
    rails (~> 6.1.3) was resolved to 6.1.3, which depends on
      railties (= 6.1.3) was resolved to 6.1.3, which depends on
        thor (~> 1.0)

    torba-rails was resolved to 1.0.2, which depends on
      torba (~> 1.0) was resolved to 1.0.1, which depends on
        thor (~> 0.19.1)
```

There's [no breaking changes](https://github.com/erikhuda/thor/blob/master/CHANGELOG.md#100) for Torba. I'm hesitant to make the dependency completely unrestricted.