### PR TITLE
Support scoped names for npm packages

### DIFF
--- a/lib/torba/remote_sources/npm.rb
+++ b/lib/torba/remote_sources/npm.rb
@@ -8,6 +8,7 @@ module Torba
       # @return [String] package name.
       # @example
       #   "coffee-script"
+      #   "@lottiefiles/lottie-player"
       attr_reader :package
 
       # @return [String] package version.
@@ -20,7 +21,12 @@ module Torba
       def initialize(package, version)
         @package = package
         @version = version
-        super("https://registry.npmjs.org/#{package}/-/#{package}-#{version}.tgz")
+
+        # https://docs.npmjs.com/about-scopes
+        # "@lottiefiles/lottie-player" => "lottie-player"
+        unscoped_package = package.sub(%r{@[^/]+/}, "")
+
+        super("https://registry.npmjs.org/#{package}/-/#{unscoped_package}-#{version}.tgz")
         @digest = "#{package}-#{Torba.digest(url)}"
       end
     end

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -80,6 +80,11 @@ module Torba
       assert_equal "coffee-script", package.name
     end
 
+    def test_npm_implicit_scoped_name
+      manifest.npm package: "@lottiefiles/lottie-player", version: "1.8.3"
+      assert_equal "@lottiefiles/lottie-player", package.name
+    end
+
     def test_npm_wo_package
       assert_raises(KeyError) do
         manifest.npm version: "1.8.3"

--- a/test/remote_sources/npm_test.rb
+++ b/test/remote_sources/npm_test.rb
@@ -30,5 +30,12 @@ module Torba
     def test_digest_contains_repository_name
       assert_match /^coffee-script-/, remote.digest
     end
+
+    def test_scoped_repo
+      remote = RemoteSources::Npm.new("@lottiefiles/lottie-player", "2.0.2")
+      assert_equal "@lottiefiles/lottie-player", remote.package
+      assert_equal "2.0.2", remote.version
+      assert_equal "https://registry.npmjs.org/@lottiefiles/lottie-player/-/lottie-player-2.0.2.tgz", remote.url
+    end
   end
 end


### PR DESCRIPTION
#42 

[Scoped names](https://docs.npmjs.com/about-scopes) were not supported before.

This PR only handles correct URL generation for fetching a package from the npm registry.

Scope is not removed when implicit name is used in manifest, hence you should either use full package name in Sprockets' `require` statement:

```ruby
# Torbafile
npm package: "@lottiefiles/lottie-player", version: "1.2.3"
```

```js
// application.js
//= require "@lottiefiles/lottie-player/lottie-player"
```

or provide an explicit package name that will be used as a namespace:

```ruby
# Torbafile
npm "lottie-player", package: "@lottiefiles/lottie-player", version: "1.2.3"
```

```js
// application.js
//= require "lottie-player/lottie-player"
```